### PR TITLE
Making the credit card values public so I can retrieve them

### DIFF
--- a/Sources/CreditCardCell.swift
+++ b/Sources/CreditCardCell.swift
@@ -12,9 +12,11 @@ import Eureka
  *  Struct holding the value for a CreditCardRow
  */
 public struct CreditCardInfo : Equatable {
-    var creditCardNumber : String?
-    var expiration : String?
-    var cvv : String?
+    public var creditCardNumber : String?
+    public var expiration : String?
+    public var cvv : String?
+    
+    public init() { }
 }
 
 public func ==(lhs: CreditCardInfo, rhs: CreditCardInfo) -> Bool {


### PR DESCRIPTION
I can't find another way to get what the user entered, unless you make these public.

For example:
<<< CreditCardRow("creditCard") 

let valuesDictionary = form.values()
        if let creditCardInfo = valuesDictionary["creditCard"] as? CreditCardInfo,
            let creditCardNumber  = creditCardInfo.creditCardNumber {
            // Do something with creditCardNumber
        }

If there's a better way, let me know.