### PR TITLE
Update CreditCardRow.podspec

### DIFF
--- a/CreditCardRow.podspec
+++ b/CreditCardRow.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     'CreditCardRow' => ['Sources/CreditCardCell.xib']
   }
   s.ios.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'Eureka', '~> 4'
+  s.dependency 'Eureka', '~> 4.0'
 end

--- a/CreditCardRow.podspec
+++ b/CreditCardRow.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     'CreditCardRow' => ['Sources/CreditCardCell.xib']
   }
   s.ios.frameworks = 'UIKit', 'Foundation'
-  s.dependency 'Eureka', '4.0'
+  s.dependency 'Eureka', '~> 4'
 end


### PR DESCRIPTION
This change allows the lib to goes along updated version of Eureka. With the current dependency definition I need to keep the Eureka version as 4.0 and can't update to Eureka 4.0.1